### PR TITLE
Clarify idle timeout choices

### DIFF
--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -37,9 +37,7 @@ class IdleTimerEvent:
     description: str
     detected_at: datetime
     last_activity_at: datetime
-    running_seconds_at_detection: int
     running_seconds_at_last_activity: int
-    idle_seconds: int
 
 
 class ToolTip:
@@ -78,6 +76,8 @@ class ToolTip:
             return
         self.tip_window.destroy()
         self.tip_window = None
+
+
 @dataclass(slots=True)
 class ReportTask:
     item: TodoItem
@@ -92,7 +92,10 @@ class IdleTimerDialog(tk.Toplevel):
         self.title("Timer stopped after inactivity")
         self.resizable(False, False)
         self.transient(master)
-        self.result = "close"
+        self.result = "discard_idle"
+        self.event = event
+        self.idle_time_var = tk.StringVar()
+        self._idle_update_id: str | None = None
 
         body = ttk.Frame(self, padding=14)
         body.grid(sticky="nsew")
@@ -100,7 +103,10 @@ class IdleTimerDialog(tk.Toplevel):
 
         ttk.Label(
             body,
-            text="The running timer was stopped because no keyboard or mouse activity was detected.",
+            text=(
+                "The timer stopped because no keyboard or mouse activity was "
+                "detected."
+            ),
             wraplength=520,
         ).grid(row=0, column=0, sticky="w", pady=(0, 10))
         ttk.Label(
@@ -110,52 +116,55 @@ class IdleTimerDialog(tk.Toplevel):
         ).grid(row=1, column=0, sticky="w", pady=(0, 6))
         ttk.Label(
             body,
-            text=(
-                f"Timer duration when stopped: "
-                f"{format_duration(event.running_seconds_at_detection)}"
-            ),
-        ).grid(row=2, column=0, sticky="w", pady=(0, 4))
+            textvariable=self.idle_time_var,
+        ).grid(row=2, column=0, sticky="w", pady=(0, 6))
         ttk.Label(
             body,
             text=(
-                f"Time at last activity: "
-                f"{format_duration(event.running_seconds_at_last_activity)}"
+                "Discard idle time stops at your last activity. "
+                "Keep time treats the idle period as work."
             ),
-        ).grid(row=3, column=0, sticky="w", pady=(0, 4))
-        ttk.Label(
-            body,
-            text=(
-                f"Idle time detected: {format_duration(event.idle_seconds)} "
-                f"since {event.last_activity_at:%Y-%m-%d %H:%M:%S}"
-            ),
-        ).grid(row=4, column=0, sticky="w", pady=(0, 12))
+            wraplength=520,
+        ).grid(row=3, column=0, sticky="w", pady=(0, 12))
 
         button_row = ttk.Frame(body)
-        button_row.grid(row=5, column=0, sticky="e")
+        button_row.grid(row=4, column=0, sticky="e")
         ttk.Button(
             button_row,
-            text="Close",
-            command=lambda: self._finish("close"),
+            text="Keep Time & Continue",
+            command=lambda: self._finish("keep_time"),
         ).pack(side="right")
         ttk.Button(
             button_row,
-            text="Reset to last activity",
-            command=lambda: self._finish("reset"),
-        ).pack(side="right", padx=(0, 8))
-        ttk.Button(
-            button_row,
-            text="Restart timer",
-            command=lambda: self._finish("restart"),
+            text="Discard Idle Time",
+            command=lambda: self._finish("discard_idle"),
         ).pack(side="right", padx=(0, 8))
 
-        self.protocol("WM_DELETE_WINDOW", lambda: self._finish("close"))
-        self.bind("<Escape>", lambda event_: self._finish("close"))
+        self.protocol("WM_DELETE_WINDOW", lambda: self._finish("discard_idle"))
+        self.bind("<Escape>", lambda event_: self._finish("discard_idle"))
         self.grab_set()
+        self._update_idle_time()
         self.update_idletasks()
         self.minsize(self.winfo_width(), self.winfo_height())
 
+    def _current_idle_seconds(self) -> int:
+        return max(
+            0,
+            int((datetime.now() - self.event.last_activity_at).total_seconds()),
+        )
+
+    def _update_idle_time(self) -> None:
+        self.idle_time_var.set(
+            "Idle time: "
+            f"{format_duration(self._current_idle_seconds())} "
+            f"since {self.event.last_activity_at:%Y-%m-%d %H:%M:%S}"
+        )
+        self._idle_update_id = self.after(1000, self._update_idle_time)
+
     def _finish(self, result: str) -> None:
         self.result = result
+        if self._idle_update_id is not None:
+            self.after_cancel(self._idle_update_id)
         self.destroy()
 
 
@@ -1816,11 +1825,9 @@ class TodoTimerApp:
             description=item.description,
             detected_at=detected_at,
             last_activity_at=last_activity_at,
-            running_seconds_at_detection=item.total_elapsed_seconds(detected_at),
             running_seconds_at_last_activity=(
                 item.time_spent_seconds + elapsed_to_last_activity
             ),
-            idle_seconds=idle_seconds,
         )
 
         self.store.stop_timer(item.id, now=detected_at)
@@ -1849,12 +1856,14 @@ class TodoTimerApp:
             return
 
         try:
-            if choice == "reset":
+            if choice == "discard_idle":
                 item.time_spent_seconds = event.running_seconds_at_last_activity
                 item.last_worked_at = event.last_activity_at
                 item.timer_started_at = None
-                self.status_var.set("Timer reset to the last activity time.")
-            elif choice == "restart":
+                self.status_var.set(
+                    "Idle time discarded; timer stopped at last activity."
+                )
+            elif choice == "keep_time":
                 if item.completed:
                     messagebox.showinfo(
                         APP_TITLE,
@@ -1862,8 +1871,14 @@ class TodoTimerApp:
                         parent=self.root,
                     )
                     return
-                self.store.start_timer(item.id)
-                self.status_var.set("Timer restarted.")
+                now = datetime.now()
+                item.time_spent_seconds += max(
+                    0,
+                    int((now - event.detected_at).total_seconds()),
+                )
+                item.last_worked_at = now
+                self.store.start_timer(item.id, now=now)
+                self.status_var.set("Idle time kept; timer is still running.")
             else:
                 self.status_var.set("Timer left stopped after inactivity.")
             self.store.save()

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -975,6 +975,11 @@ class TodoTimerApp:
             "<Control-t>", lambda event: self.toggle_timer_selected() or "break"
         )
         self.root.bind_all("<Control-l>", lambda event: self.open_first_link())
+        for sequence in ("<Control-Alt-Shift-b>", "<Control-Alt-Shift-B>"):
+            self.root.bind_all(
+                sequence,
+                lambda event: self.debug_trigger_idle_timeout() or "break",
+            )
 
     def _bind_activity_tracking(self) -> None:
         for sequence in (
@@ -1810,9 +1815,25 @@ class TodoTimerApp:
         if idle_seconds < threshold_seconds:
             return
 
+        self.trigger_idle_timeout(idle_seconds)
+
+    def debug_trigger_idle_timeout(self) -> None:
+        if self.idle_dialog_open:
+            return
+        forced_idle_seconds = max(1, self.idle_timeout_minutes * 60)
+        if not self.trigger_idle_timeout(forced_idle_seconds):
+            self.status_var.set("Start a timer before testing idle timeout.")
+
+    def trigger_idle_timeout(self, idle_seconds: int) -> bool:
+        if self.idle_dialog_open:
+            return False
+        running = self.store.running_items()
+        if not running:
+            return False
+
         item = running[0]
         if item.timer_started_at is None:
-            return
+            return False
 
         detected_at = datetime.now()
         last_activity_at = detected_at - timedelta(seconds=idle_seconds)
@@ -1835,6 +1856,7 @@ class TodoTimerApp:
         self.refresh_tree(select_item_id=item.id)
         self.status_var.set("Timer stopped after keyboard/mouse inactivity.")
         self._show_idle_timer_dialog(event)
+        return True
 
     def _show_idle_timer_dialog(self, event: IdleTimerEvent) -> None:
         self.idle_dialog_open = True


### PR DESCRIPTION
## Summary
- Replace the idle timeout dialog's three ambiguous choices with two clearer actions.
- Show a live idle-time counter that continues from the last keyboard/mouse activity while the dialog is open.
- Rename the choices to **Discard Idle Time** and **Keep Time & Continue**.
- When keeping time, account for the time spent while the dialog was open and restart the timer as though it had continued.
- Add `Ctrl+Alt+Shift+B` as a debug shortcut to trigger the idle timeout flow immediately for testing.

## Behavior notes
**Discard Idle Time** stops the timer at the last activity timestamp. **Keep Time & Continue** treats the idle period as work time and keeps the timer running.

The debug shortcut uses the same timeout flow as the normal idle checker and simulates the configured idle timeout duration.

## Validation
- `python -m py_compile todo_core.py todo_timer.pyw`
- `git diff --check`