### PR TITLE
Add project tag column and filter bar

### DIFF
--- a/todo_core.py
+++ b/todo_core.py
@@ -150,6 +150,7 @@ class AppConfig:
     archive_file: str = ""
     openai_api_key: str = ""
     last_closed_at: str = ""
+    project_filter: str = ""
     window_geometry: str = ""
     sort_mode: str = "priority"
     show_completed: bool = True

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -1905,6 +1905,14 @@ class TodoTimerApp:
             shown.append(f"+{len(projects) - len(shown)}")
         return " ".join(shown)
 
+    @staticmethod
+    def task_text_without_projects(item: TodoItem) -> str:
+        return " ".join(
+            token
+            for token in item.description.split()
+            if token not in item.projects
+        )
+
     def on_sort_changed(self) -> None:
         self.sort_mode = self.sort_var.get()
         self.refresh_tree()
@@ -1954,7 +1962,7 @@ class TodoTimerApp:
                     item.creation_date or "",
                     last_worked,
                     spent + (" ▶" if item.timer_started_at else ""),
-                    item.description,
+                    self.task_text_without_projects(item),
                 ),
                 tags=tags,
             )

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -1893,7 +1893,7 @@ class TodoTimerApp:
         if not filter_terms:
             return True
         item_projects = {project.casefold() for project in item.projects}
-        return any(
+        return all(
             (tag not in item_projects if is_excluded else tag in item_projects)
             for tag, is_excluded in filter_terms
         )

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -718,7 +718,11 @@ class TodoTimerApp:
         self.archive_path_var = tk.StringVar(
             value=self.config.archive_file.strip()
         )
+        self.project_filter_var = tk.StringVar(
+            value=self.config.project_filter.strip()
+        )
         self.status_var = tk.StringVar(value="Open a todo.txt file to begin.")
+        self.filter_status_var = tk.StringVar(value="")
         self.config_status_var = tk.StringVar(value="")
         self.todo_status_var = tk.StringVar(value="")
         self.archive_status_var = tk.StringVar(value="")
@@ -916,28 +920,38 @@ class TodoTimerApp:
         table_frame.rowconfigure(0, weight=1)
 
         shortcut_frame = ttk.Frame(outer)
-        shortcut_frame.grid(row=2, column=0, sticky="ew", pady=(8, 0))
+        shortcut_frame.grid(row=4, column=0, sticky="ew", pady=(3, 0))
         ttk.Label(
             shortcut_frame,
             text="[Ctrl+t] start/stop timer | [F2] edit entry | [Ctrl+l] open first link | [x] mark complete | [Del] delete task",
         ).grid(row=0, column=0, sticky="w")
 
-        columns = ("done", "priority", "created", "lastworked", "spent", "task")
+        columns = (
+            "projects",
+            "done",
+            "priority",
+            "created",
+            "lastworked",
+            "spent",
+            "task",
+        )
         self.tree = ttk.Treeview(
             table_frame, columns=columns, show="headings", selectmode="browse"
         )
+        self.tree.heading("projects", text="+ Tags")
         self.tree.heading("done", text="✔️")
         self.tree.heading("priority", text="⚑")
         self.tree.heading("created", text="🌱")
         self.tree.heading("lastworked", text="⚒")
         self.tree.heading("spent", text="⏱️")
         self.tree.heading("task", text="Task")
+        self.tree.column("projects", width=150, anchor="w", stretch=False)
         self.tree.column("done", width=20, anchor="center", stretch=False)
         self.tree.column("priority", width=20, anchor="center", stretch=False)
         self.tree.column("created", width=80, anchor="center", stretch=False)
         self.tree.column("lastworked", width=80, anchor="center", stretch=False)
         self.tree.column("spent", width=70, anchor="center", stretch=False)
-        self.tree.column("task", width=600, anchor="w", stretch=True)
+        self.tree.column("task", width=560, anchor="w", stretch=True)
         self.tree.grid(row=0, column=0, sticky="nsew")
         self.tree.bind("<Double-1>", lambda event: self.edit_selected())
 
@@ -950,8 +964,36 @@ class TodoTimerApp:
         self.tree.tag_configure("completed", foreground="#7a7a7a")
         self.tree.tag_configure("running", font=("Segoe UI", 9, "bold"))
 
+        filter_frame = ttk.Frame(outer)
+        filter_frame.grid(row=2, column=0, sticky="ew", pady=(8, 0))
+        filter_frame.columnconfigure(1, weight=1)
+        ttk.Label(filter_frame, text="+ Tag filters").grid(
+            row=0, column=0, sticky="w", padx=(0, 8)
+        )
+        self.project_filter_entry = ttk.Entry(
+            filter_frame,
+            textvariable=self.project_filter_var,
+        )
+        self.project_filter_entry.grid(row=0, column=1, sticky="ew")
+        self.project_filter_entry.bind(
+            "<Escape>",
+            lambda event: self.clear_project_filter() or "break",
+        )
+        self.project_filter_var.trace_add(
+            "write",
+            lambda *args: self.on_project_filter_changed(),
+        )
+
+        filter_status_frame = ttk.Frame(outer)
+        filter_status_frame.grid(row=3, column=0, sticky="ew", pady=(3, 0))
+        filter_status_frame.columnconfigure(0, weight=1)
+        ttk.Label(
+            filter_status_frame,
+            textvariable=self.filter_status_var,
+        ).grid(row=0, column=0, sticky="w")
+
         idle_status_frame = ttk.Frame(outer)
-        idle_status_frame.grid(row=3, column=0, sticky="ew", pady=(3, 0))
+        idle_status_frame.grid(row=5, column=0, sticky="ew", pady=(3, 0))
         idle_status_frame.columnconfigure(0, weight=1)
         ttk.Label(
             idle_status_frame,
@@ -959,14 +1001,14 @@ class TodoTimerApp:
         ).grid(row=0, column=0, sticky="w")
 
         status_frame = ttk.Frame(outer)
-        status_frame.grid(row=4, column=0, sticky="ew", pady=(3, 0))
+        status_frame.grid(row=6, column=0, sticky="ew", pady=(3, 0))
         status_frame.columnconfigure(0, weight=1)
         ttk.Label(status_frame, textvariable=self.status_var).grid(
             row=0, column=0, sticky="w"
         )
 
         connection_frame = ttk.Frame(outer)
-        connection_frame.grid(row=5, column=0, sticky="ew", pady=(3, 0))
+        connection_frame.grid(row=7, column=0, sticky="ew", pady=(3, 0))
         connection_frame.columnconfigure(3, weight=1)
         self.config_status_label = ttk.Label(
             connection_frame,
@@ -1814,6 +1856,56 @@ class TodoTimerApp:
             f"Idle timeout set to {self.idle_timeout_minutes} minute(s)."
         )
 
+    def on_project_filter_changed(self) -> None:
+        self.config.project_filter = self.project_filter_var.get().strip()
+        self.refresh_tree()
+
+    def clear_project_filter(self) -> None:
+        if self.project_filter_var.get():
+            self.project_filter_var.set("")
+
+    def project_filter_groups(self) -> list[tuple[str, ...]]:
+        expression = self.project_filter_var.get().strip()
+        if not expression:
+            return []
+
+        groups: list[tuple[str, ...]] = []
+        for group_text in expression.split("||"):
+            tags: list[str] = []
+            for term_text in group_text.split("&&"):
+                for raw_tag in term_text.replace(",", " ").split():
+                    tag = raw_tag.strip()
+                    if not tag:
+                        continue
+                    if not tag.startswith("+"):
+                        tag = f"+{tag}"
+                    tag_key = tag.casefold()
+                    if tag_key not in tags:
+                        tags.append(tag_key)
+            if tags:
+                groups.append(tuple(tags))
+        return groups
+
+    def item_matches_project_filter(
+        self,
+        item: TodoItem,
+        filter_groups: list[tuple[str, ...]],
+    ) -> bool:
+        if not filter_groups:
+            return True
+        item_projects = {project.casefold() for project in item.projects}
+        return any(
+            all(tag in item_projects for tag in group)
+            for group in filter_groups
+        )
+
+    @staticmethod
+    def format_project_tags(projects: list[str]) -> str:
+        shown = projects[:4]
+        if len(projects) > len(shown):
+            shown.append(f"+{len(projects) - len(shown)}")
+        return " ".join(shown)
+
     def on_sort_changed(self) -> None:
         self.sort_mode = self.sort_var.get()
         self.refresh_tree()
@@ -1825,12 +1917,18 @@ class TodoTimerApp:
         for child in self.tree.get_children():
             self.tree.delete(child)
 
-        show_completed = self.show_completed_var.get()
-        items = list(
+        visible_by_completion = list(
             self.store.iter_sorted(
-                self.sort_mode, show_completed=show_completed
+                self.sort_mode,
+                show_completed=self.show_completed_var.get(),
             )
         )
+        filter_groups = self.project_filter_groups()
+        items = [
+            item
+            for item in visible_by_completion
+            if self.item_matches_project_filter(item, filter_groups)
+        ]
         for item in items:
             tags: tuple[str, ...] = tuple(
                 tag
@@ -1851,6 +1949,7 @@ class TodoTimerApp:
                 "end",
                 iid=item.id,
                 values=(
+                    self.format_project_tags(item.projects),
                     "x" if item.completed else "",
                     item.priority or "",
                     item.creation_date or "",
@@ -1869,9 +1968,19 @@ class TodoTimerApp:
         total = len(self.store.items)
         complete = sum(item.completed for item in self.store.items)
         incomplete = total - complete
+        visible_total = len(visible_by_completion)
         self.status_var.set(
             f"Tasks: {total} total | {incomplete} incomplete | {complete} complete | Sort: {self.sort_mode}"
         )
+        filter_text = self.project_filter_var.get().strip()
+        if filter_text:
+            self.filter_status_var.set(
+                f"Showing {len(items)} of {visible_total} tasks due to filters: {filter_text}"
+            )
+        else:
+            self.filter_status_var.set(
+                f"Showing {len(items)} of {visible_total} tasks."
+            )
 
     def update_connection_status(self) -> None:
         config_ok = self.config_store.loaded
@@ -2098,6 +2207,7 @@ class TodoTimerApp:
         self.config.last_closed_at = (
             format_timestamp(now) if self.store.running_items() else ""
         )
+        self.config.project_filter = self.project_filter_var.get().strip()
         self.config.window_geometry = self.root.geometry()
         self.config.sort_mode = self.sort_mode
         self.config.show_completed = self.show_completed_var.get()

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -1869,24 +1869,18 @@ class TodoTimerApp:
         if not expression:
             return []
 
-        normalized = (
-            expression.replace("&&", " ")
-            .replace("||", " ")
-            .replace(",", " ")
-        )
         terms: list[tuple[str, bool]] = []
-        for raw_tag in normalized.split():
+        for raw_tag in expression.split():
             tag = raw_tag.strip()
             if not tag:
                 continue
-            is_excluded = tag.startswith("!")
-            if is_excluded:
+            if tag.startswith("!"):
                 tag = tag[1:].strip()
                 if not tag:
                     continue
             if not tag.startswith("+"):
                 tag = f"+{tag}"
-            term = (tag.casefold(), is_excluded)
+            term = (tag.casefold(), raw_tag.strip().startswith("!"))
             if term not in terms:
                 terms.append(term)
         return terms

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -88,12 +88,6 @@ class ReportTask:
     activity_date: str
 
 
-@dataclass(slots=True)
-class ProjectFilterGroup:
-    required: tuple[str, ...]
-    excluded: tuple[str, ...]
-
-
 class IdleTimerDialog(tk.Toplevel):
     def __init__(self, master: tk.Misc, event: IdleTimerEvent):
         super().__init__(master)
@@ -1870,52 +1864,44 @@ class TodoTimerApp:
         if self.project_filter_var.get():
             self.project_filter_var.set("")
 
-    def project_filter_groups(self) -> list[ProjectFilterGroup]:
+    def project_filter_terms(self) -> list[tuple[str, bool]]:
         expression = self.project_filter_var.get().strip()
         if not expression:
             return []
 
-        groups: list[ProjectFilterGroup] = []
-        for group_text in expression.split("||"):
-            required: list[str] = []
-            excluded: list[str] = []
-            for term_text in group_text.split("&&"):
-                for raw_tag in term_text.replace(",", " ").split():
-                    tag = raw_tag.strip()
-                    if not tag:
-                        continue
-                    is_excluded = tag.startswith("!")
-                    if is_excluded:
-                        tag = tag[1:].strip()
-                        if not tag:
-                            continue
-                    if not tag.startswith("+"):
-                        tag = f"+{tag}"
-                    tag_key = tag.casefold()
-                    target = excluded if is_excluded else required
-                    if tag_key not in target:
-                        target.append(tag_key)
-            if required or excluded:
-                groups.append(
-                    ProjectFilterGroup(
-                        required=tuple(required),
-                        excluded=tuple(excluded),
-                    )
-                )
-        return groups
+        normalized = (
+            expression.replace("&&", " ")
+            .replace("||", " ")
+            .replace(",", " ")
+        )
+        terms: list[tuple[str, bool]] = []
+        for raw_tag in normalized.split():
+            tag = raw_tag.strip()
+            if not tag:
+                continue
+            is_excluded = tag.startswith("!")
+            if is_excluded:
+                tag = tag[1:].strip()
+                if not tag:
+                    continue
+            if not tag.startswith("+"):
+                tag = f"+{tag}"
+            term = (tag.casefold(), is_excluded)
+            if term not in terms:
+                terms.append(term)
+        return terms
 
     def item_matches_project_filter(
         self,
         item: TodoItem,
-        filter_groups: list[ProjectFilterGroup],
+        filter_terms: list[tuple[str, bool]],
     ) -> bool:
-        if not filter_groups:
+        if not filter_terms:
             return True
         item_projects = {project.casefold() for project in item.projects}
         return any(
-            all(tag in item_projects for tag in group.required)
-            and not any(tag in item_projects for tag in group.excluded)
-            for group in filter_groups
+            (tag not in item_projects if is_excluded else tag in item_projects)
+            for tag, is_excluded in filter_terms
         )
 
     @staticmethod
@@ -1942,11 +1928,11 @@ class TodoTimerApp:
                 show_completed=self.show_completed_var.get(),
             )
         )
-        filter_groups = self.project_filter_groups()
+        filter_terms = self.project_filter_terms()
         items = [
             item
             for item in visible_by_completion
-            if self.item_matches_project_filter(item, filter_groups)
+            if self.item_matches_project_filter(item, filter_terms)
         ]
         for item in items:
             tags: tuple[str, ...] = tuple(

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -88,6 +88,12 @@ class ReportTask:
     activity_date: str
 
 
+@dataclass(slots=True)
+class ProjectFilterGroup:
+    required: tuple[str, ...]
+    excluded: tuple[str, ...]
+
+
 class IdleTimerDialog(tk.Toplevel):
     def __init__(self, master: tk.Misc, event: IdleTimerEvent):
         super().__init__(master)
@@ -1864,38 +1870,51 @@ class TodoTimerApp:
         if self.project_filter_var.get():
             self.project_filter_var.set("")
 
-    def project_filter_groups(self) -> list[tuple[str, ...]]:
+    def project_filter_groups(self) -> list[ProjectFilterGroup]:
         expression = self.project_filter_var.get().strip()
         if not expression:
             return []
 
-        groups: list[tuple[str, ...]] = []
+        groups: list[ProjectFilterGroup] = []
         for group_text in expression.split("||"):
-            tags: list[str] = []
+            required: list[str] = []
+            excluded: list[str] = []
             for term_text in group_text.split("&&"):
                 for raw_tag in term_text.replace(",", " ").split():
                     tag = raw_tag.strip()
                     if not tag:
                         continue
+                    is_excluded = tag.startswith("!")
+                    if is_excluded:
+                        tag = tag[1:].strip()
+                        if not tag:
+                            continue
                     if not tag.startswith("+"):
                         tag = f"+{tag}"
                     tag_key = tag.casefold()
-                    if tag_key not in tags:
-                        tags.append(tag_key)
-            if tags:
-                groups.append(tuple(tags))
+                    target = excluded if is_excluded else required
+                    if tag_key not in target:
+                        target.append(tag_key)
+            if required or excluded:
+                groups.append(
+                    ProjectFilterGroup(
+                        required=tuple(required),
+                        excluded=tuple(excluded),
+                    )
+                )
         return groups
 
     def item_matches_project_filter(
         self,
         item: TodoItem,
-        filter_groups: list[tuple[str, ...]],
+        filter_groups: list[ProjectFilterGroup],
     ) -> bool:
         if not filter_groups:
             return True
         item_projects = {project.casefold() for project in item.projects}
         return any(
-            all(tag in item_projects for tag in group)
+            all(tag in item_projects for tag in group.required)
+            and not any(tag in item_projects for tag in group.excluded)
             for group in filter_groups
         )
 


### PR DESCRIPTION
## Summary
- Add a left-side `+ Tags` column that shows todo.txt project markers such as `+work` and `+personal`.
- Hide project tags from the main Task column because they are shown in the `+ Tags` column.
- Add a project filter text box directly under the task table.
- Treat whitespace-separated filter terms as AND matches, with plain names normalized to `+name`.
- Support `!` for inverted terms, so `!personal +spring` excludes personal tasks and requires `+spring`.
- Show a visible count line such as `Showing x of n tasks due to filters` when filtering is active.
- Persist the current project filter in `config.json`.

Closes #35.

## Validation
- `python -m py_compile todo_core.py todo_timer.pyw`
- `git diff --check`