### PR TITLE
Add manual task time adjustment

### DIFF
--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -820,6 +820,119 @@ class QuickNoteDialog(tk.Toplevel):
         self.destroy()
 
 
+class AdjustTimeDialog(tk.Toplevel):
+    QUICK_MINUTES = (1, 5, 15, 60)
+
+    def __init__(self, master: tk.Misc, item: TodoItem):
+        super().__init__(master)
+        self.title("Adjust tracked time")
+        self.resizable(False, False)
+        self.transient(master)
+        self.result_minutes: int | None = None
+        self.adjustment_var = tk.StringVar(value="+0")
+
+        body = ttk.Frame(self, padding=12)
+        body.grid(sticky="nsew")
+        body.columnconfigure(1, weight=1)
+
+        ttk.Label(body, text="Task").grid(
+            row=0, column=0, sticky="nw", padx=(0, 8), pady=(0, 8)
+        )
+        ttk.Label(
+            body,
+            text=serialize_todo_line(item),
+            wraplength=640,
+        ).grid(row=0, column=1, sticky="ew", pady=(0, 8))
+
+        ttk.Label(body, text="Current time").grid(
+            row=1, column=0, sticky="w", padx=(0, 8), pady=(0, 8)
+        )
+        ttk.Label(
+            body,
+            text=format_duration(item.total_elapsed_seconds()),
+        ).grid(row=1, column=1, sticky="w", pady=(0, 8))
+
+        ttk.Label(body, text="Adjustment").grid(
+            row=2, column=0, sticky="w", padx=(0, 8), pady=(0, 8)
+        )
+        adjustment_row = ttk.Frame(body)
+        adjustment_row.grid(row=2, column=1, sticky="w", pady=(0, 8))
+        self.adjustment_entry = ttk.Entry(
+            adjustment_row,
+            textvariable=self.adjustment_var,
+            width=10,
+        )
+        self.adjustment_entry.pack(side="left")
+        ttk.Label(
+            adjustment_row,
+            text="minutes; + adds, - subtracts",
+        ).pack(side="left", padx=(8, 0))
+
+        quick_frame = ttk.LabelFrame(body, text="Quick adjust")
+        quick_frame.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(0, 8))
+        for minutes in self.QUICK_MINUTES:
+            ttk.Button(
+                quick_frame,
+                text=f"+{minutes}",
+                width=6,
+                command=lambda minutes=minutes: self.add_minutes(minutes),
+            ).pack(side="left", padx=(0, 4), pady=6)
+        for minutes in self.QUICK_MINUTES:
+            ttk.Button(
+                quick_frame,
+                text=f"-{minutes}",
+                width=6,
+                command=lambda minutes=minutes: self.add_minutes(-minutes),
+            ).pack(side="left", padx=(8 if minutes == 1 else 0, 4), pady=6)
+
+        button_row = ttk.Frame(body)
+        button_row.grid(row=4, column=0, columnspan=2, sticky="e", pady=(4, 0))
+        ttk.Button(button_row, text="Cancel", command=self.destroy).pack(
+            side="right"
+        )
+        ttk.Button(button_row, text="Save", command=self._on_save).pack(
+            side="right", padx=(0, 8)
+        )
+
+        self.bind("<Escape>", lambda event: self.destroy())
+        self.bind("<Control-Return>", lambda event: self._on_save())
+        self.adjustment_entry.focus_set()
+        self.adjustment_entry.selection_range(0, "end")
+        self.update_idletasks()
+        center_dialog_on_master(self, master)
+        self.minsize(self.winfo_width(), self.winfo_height())
+        self.grab_set()
+
+    def current_adjustment_minutes(self) -> int:
+        value = self.adjustment_var.get().strip()
+        if not value:
+            return 0
+        return int(value)
+
+    def set_adjustment_minutes(self, minutes: int) -> None:
+        sign = "+" if minutes >= 0 else ""
+        self.adjustment_var.set(f"{sign}{minutes}")
+
+    def add_minutes(self, minutes: int) -> None:
+        try:
+            current = self.current_adjustment_minutes()
+        except ValueError:
+            current = 0
+        self.set_adjustment_minutes(current + minutes)
+
+    def _on_save(self) -> None:
+        try:
+            self.result_minutes = self.current_adjustment_minutes()
+        except ValueError:
+            messagebox.showerror(
+                APP_TITLE,
+                "Adjustment must be whole minutes, like +15 or -5.",
+                parent=self,
+            )
+            return
+        self.destroy()
+
+
 class TodoTimerApp:
     def __init__(self) -> None:
         self.root = tk.Tk()
@@ -963,6 +1076,11 @@ class TodoTimerApp:
             accelerator="Ctrl+T",
             command=self.toggle_timer_selected,
         )
+        task_menu.add_command(
+            label="Adjust tracked time...",
+            accelerator="Ctrl+Alt+T",
+            command=self.adjust_time_selected,
+        )
         task_menu.add_separator()
         task_menu.add_command(
             label="Increase priority",
@@ -1073,7 +1191,7 @@ class TodoTimerApp:
         shortcut_frame.grid(row=4, column=0, sticky="ew", pady=(3, 0))
         ttk.Label(
             shortcut_frame,
-            text="[Ctrl+t] start/stop timer | [F2] edit entry | [Ctrl+Alt+A] append note | [Ctrl+l] open first link | [x] mark complete | [Del] delete task",
+            text="[Ctrl+t] start/stop timer | [Ctrl+Alt+T] adjust time | [F2] edit entry | [Ctrl+Alt+A] append note | [Ctrl+l] open first link | [x] mark complete | [Del] delete task",
         ).grid(row=0, column=0, sticky="w")
 
         self.tree = ttk.Treeview(
@@ -1229,6 +1347,11 @@ class TodoTimerApp:
         self.tree.bind(
             "<Control-t>", lambda event: self.toggle_timer_selected() or "break"
         )
+        for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
+            self.root.bind_all(
+                sequence,
+                lambda event: self.adjust_time_selected() or "break",
+            )
         for sequence in ("<Control-Alt-a>", "<Control-Alt-A>"):
             self.root.bind_all(
                 sequence,
@@ -1330,6 +1453,7 @@ class TodoTimerApp:
                 "  F2 edit\n"
                 "  Alt+Up / Alt+Down change priority\n"
                 "  Ctrl+T start/stop timer\n"
+                "  Ctrl+Alt+T adjust tracked time\n"
                 "  Ctrl+Alt+A append note\n"
                 "  Ctrl+L open first link\n"
                 "  Ctrl+Shift+A archive completed tasks\n"
@@ -1966,6 +2090,38 @@ class TodoTimerApp:
         except Exception as exc:
             messagebox.showerror(
                 APP_TITLE, f"Could not toggle timer:\n{exc}", parent=self.root
+            )
+
+    def adjust_time_selected(self) -> None:
+        item = self.selected_item()
+        if item is None:
+            return
+        dialog = AdjustTimeDialog(self.root, item)
+        self.root.wait_window(dialog)
+        if dialog.result_minutes is None:
+            return
+        delta_seconds = dialog.result_minutes * 60
+        try:
+            self.ensure_file_loaded()
+            current_total = item.total_elapsed_seconds()
+            new_total = max(0, current_total + delta_seconds)
+            if item.timer_started_at is None:
+                item.time_spent_seconds = new_total
+            else:
+                item.time_spent_seconds = 0
+                item.timer_started_at = datetime.now() - timedelta(
+                    seconds=new_total
+                )
+            self.store.save()
+            self.refresh_tree(select_item_id=item.id)
+            self.status_var.set(
+                f"Adjusted tracked time to {format_duration(new_total)}."
+            )
+        except Exception as exc:
+            messagebox.showerror(
+                APP_TITLE,
+                f"Could not adjust tracked time:\n{exc}",
+                parent=self.root,
             )
 
     def increase_priority(self) -> None:

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -33,7 +33,6 @@ APP_TITLE = "TodoTimerTXT"
 DEFAULT_IDLE_TIMEOUT_MINUTES = 10
 REPORT_MODEL = "gpt-5-mini"
 OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
-TK_ALT_MASK = 0x0008
 TREE_COLUMNS = (
     "projects",
     "done",
@@ -1345,19 +1344,11 @@ class TodoTimerApp:
             "x",
             lambda event: self.toggle_complete_selected() or "break",
         )
-        for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
-            self.tree.bind(
-                sequence,
-                lambda event: self.adjust_time_selected() or "break",
-            )
+        self.bind_adjust_time_shortcut(self.tree.bind)
         self.tree.bind(
-            "<Control-t>", lambda event: self.handle_timer_shortcut(event)
+            "<Control-t>", lambda event: self.toggle_timer_selected() or "break"
         )
-        for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
-            self.root.bind_all(
-                sequence,
-                lambda event: self.adjust_time_selected() or "break",
-            )
+        self.bind_adjust_time_shortcut(self.root.bind_all)
         for sequence in ("<Control-Alt-a>", "<Control-Alt-A>"):
             self.root.bind_all(
                 sequence,
@@ -1370,12 +1361,12 @@ class TodoTimerApp:
                 lambda event: self.debug_trigger_idle_timeout() or "break",
             )
 
-    def handle_timer_shortcut(self, event: tk.Event[tk.Widget]) -> str:
-        if event.state & TK_ALT_MASK:
-            self.adjust_time_selected()
-        else:
-            self.toggle_timer_selected()
-        return "break"
+    def bind_adjust_time_shortcut(self, bind_method) -> None:
+        for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
+            bind_method(
+                sequence,
+                lambda event: self.adjust_time_selected() or "break",
+            )
 
     def _bind_activity_tracking(self) -> None:
         for sequence in (

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -33,6 +33,7 @@ APP_TITLE = "TodoTimerTXT"
 DEFAULT_IDLE_TIMEOUT_MINUTES = 10
 REPORT_MODEL = "gpt-5-mini"
 OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+TK_ALT_MASK = 0x0008
 TREE_COLUMNS = (
     "projects",
     "done",
@@ -1344,8 +1345,13 @@ class TodoTimerApp:
             "x",
             lambda event: self.toggle_complete_selected() or "break",
         )
+        for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
+            self.tree.bind(
+                sequence,
+                lambda event: self.adjust_time_selected() or "break",
+            )
         self.tree.bind(
-            "<Control-t>", lambda event: self.toggle_timer_selected() or "break"
+            "<Control-t>", lambda event: self.handle_timer_shortcut(event)
         )
         for sequence in ("<Control-Alt-t>", "<Control-Alt-T>"):
             self.root.bind_all(
@@ -1363,6 +1369,13 @@ class TodoTimerApp:
                 sequence,
                 lambda event: self.debug_trigger_idle_timeout() or "break",
             )
+
+    def handle_timer_shortcut(self, event: tk.Event[tk.Widget]) -> str:
+        if event.state & TK_ALT_MASK:
+            self.adjust_time_selected()
+        else:
+            self.toggle_timer_selected()
+        return "break"
 
     def _bind_activity_tracking(self) -> None:
         for sequence in (


### PR DESCRIPTION
## Summary
- Add `Ctrl+Alt+T` and a Task menu item for adjusting tracked time on the selected task.
- Keep plain `Ctrl+T` bound directly to start/stop timer, and bind `Ctrl+Alt+T` separately to adjust time so the shortcuts do not route through a shared modifier-mask guess.
- Add an adjustment dialog showing the task, current tracked time, and a signed minutes input where `+` adds and `-` subtracts.
- Add quick buttons for `+/- 1`, `+/- 5`, `+/- 15`, and `+/- 60` minutes that accumulate into the adjustment input.
- Clamp adjusted tracked time at zero when subtracting.
- If the task timer is running, keep it running while making the displayed total match the adjusted total.
- Save `todo.txt` and refresh the selected row after applying the change.

Closes #46.

## Validation
- `python -m py_compile todo_core.py todo_timer.pyw`
- `git diff --check origin/main...HEAD`