### PR TITLE
Add Firestore task document translation helpers

### DIFF
--- a/todo_core.py
+++ b/todo_core.py
@@ -634,19 +634,14 @@ def ensure_task_id(item: TodoItem) -> str:
 
 def todo_item_to_firestore_document(
     item: TodoItem,
-    source_id: str = "",
-    *,
-    assign_task_id: bool = False,
+    source_id: str,
 ) -> dict[str, object]:
     """Converts a parsed todo item into a Firestore task document.
 
     Args:
         item: Todo item parsed from a todo.txt line.
         source_id: Source identifier for the local todo.txt file that owns the
-            task. Empty string means the caller has not assigned a source yet.
-        assign_task_id: When true, assign ``item.task_id`` if it is missing so
-            the resulting document can be matched back to the todo.txt line on
-            later syncs.
+            task.
 
     Returns:
         Firestore-ready dictionary with these keys:
@@ -656,10 +651,12 @@ def todo_item_to_firestore_document(
         ``time_spent_seconds`` (int), ``timer_started_at`` (str),
         ``last_worked_at`` (str), and ``line_index`` (int).
     """
-    task_id = ensure_task_id(item) if assign_task_id else item.task_id
+    if not source_id:
+        raise TodoFormatError("Firestore task documents require a source id.")
+    task_id = ensure_task_id(item)
     return {
         "schema_version": FIRESTORE_TASK_SCHEMA_VERSION,
-        "tid": task_id or "",
+        "tid": task_id,
         "source_id": source_id,
         "description": item.description,
         "completed": item.completed,
@@ -751,7 +748,6 @@ def todo_text_to_firestore_documents(
             todo_item_to_firestore_document(
                 item,
                 source_id,
-                assign_task_id=assign_task_ids,
             )
         )
     return documents

--- a/todo_core.py
+++ b/todo_core.py
@@ -614,6 +614,77 @@ def serialize_todo_line(item: TodoItem) -> str:
 
 
 FIRESTORE_TASK_SCHEMA_VERSION = 1
+FIRESTORE_TASK_DOCUMENT_SCHEMA: dict[str, type] = {
+    "schema_version": int,
+    "tid": str,
+    "source_id": str,
+    "description": str,
+    "completed": bool,
+    "priority": str,
+    "creation_date": str,
+    "completion_date": str,
+    "time_spent_seconds": int,
+    "timer_started_at": str,
+    "last_worked_at": str,
+    "line_index": int,
+}
+
+
+def validate_firestore_task_document(document: Mapping[str, object]) -> None:
+    """Validates a Firestore task document against the canonical schema.
+
+    Args:
+        document: Firestore task document with exactly the keys described by
+            ``FIRESTORE_TASK_DOCUMENT_SCHEMA``.
+
+    Raises:
+        TodoFormatError: If required fields are missing, extra fields are
+            present, field types do not match, or todo metadata values are
+            invalid.
+    """
+    expected_fields = set(FIRESTORE_TASK_DOCUMENT_SCHEMA)
+    actual_fields = set(document)
+    missing_fields = sorted(expected_fields - actual_fields)
+    if missing_fields:
+        raise TodoFormatError(
+            "Firestore task document missing fields: "
+            + ", ".join(missing_fields)
+        )
+    extra_fields = sorted(actual_fields - expected_fields)
+    if extra_fields:
+        raise TodoFormatError(
+            "Firestore task document has unexpected fields: "
+            + ", ".join(extra_fields)
+        )
+
+    for field_name, expected_type in FIRESTORE_TASK_DOCUMENT_SCHEMA.items():
+        value = document[field_name]
+        if type(value) is not expected_type:
+            raise TodoFormatError(
+                f"Firestore task document field {field_name!r} must be "
+                f"{expected_type.__name__}."
+            )
+
+    if document["schema_version"] != FIRESTORE_TASK_SCHEMA_VERSION:
+        raise TodoFormatError(
+            "Unsupported Firestore task document schema version: "
+            f"{document['schema_version']!r}."
+        )
+    validate_task_id(document["tid"])
+    validate_task_id(document["source_id"])
+    normalize_priority(document["priority"] or None)
+    parse_date_string(document["creation_date"] or None)
+    parse_date_string(document["completion_date"] or None)
+    parse_timestamp(document["timer_started_at"] or None)
+    parse_timestamp(document["last_worked_at"] or None)
+    if document["time_spent_seconds"] < 0:
+        raise TodoFormatError(
+            "Firestore task document time_spent_seconds must be non-negative."
+        )
+    if document["line_index"] < 0:
+        raise TodoFormatError(
+            "Firestore task document line_index must be non-negative."
+        )
 
 
 def ensure_task_id(item: TodoItem) -> str:
@@ -644,17 +715,13 @@ def todo_item_to_firestore_document(
             task.
 
     Returns:
-        Firestore-ready dictionary with these keys:
-        ``schema_version`` (int), ``tid`` (str), ``source_id`` (str),
-        ``description`` (str), ``completed`` (bool), ``priority`` (str),
-        ``creation_date`` (str), ``completion_date`` (str),
-        ``time_spent_seconds`` (int), ``timer_started_at`` (str),
-        ``last_worked_at`` (str), and ``line_index`` (int).
+        Firestore-ready dictionary matching
+        ``FIRESTORE_TASK_DOCUMENT_SCHEMA``.
     """
     if not source_id:
         raise TodoFormatError("Firestore task documents require a source id.")
     task_id = ensure_task_id(item)
-    return {
+    document: dict[str, object] = {
         "schema_version": FIRESTORE_TASK_SCHEMA_VERSION,
         "tid": task_id,
         "source_id": source_id,
@@ -676,6 +743,8 @@ def todo_item_to_firestore_document(
         ),
         "line_index": item.line_index,
     }
+    validate_firestore_task_document(document)
+    return document
 
 
 def firestore_document_to_todo_item(document: Mapping[str, object]) -> TodoItem:

--- a/todo_core.py
+++ b/todo_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 import json
 import os
 import re
@@ -15,6 +15,7 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$")
 PRIORITY_RE = re.compile(r"^\(([A-Z])\1*\)$")
 URL_RE = re.compile(r"https?://\S+")
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 DATE_FMT = "%Y-%m-%d"
 DATETIME_FMT = "%Y-%m-%d-%H-%M-%S"
@@ -122,6 +123,33 @@ def priority_sort_key(priority: str | None) -> tuple[str, int]:
     return (normalized[0], -len(normalized))
 
 
+def normalize_task_id(value: str | None) -> str | None:
+    """Normalizes a stable task id used for sync matching.
+
+    Args:
+        value: Task id text from a ``tid:<value>`` token or Firestore task
+            document. Empty strings and ``None`` mean no stable task id.
+
+    Returns:
+        Normalized task id text, or ``None`` when no task id was provided.
+
+    Raises:
+        TodoFormatError: If the id contains characters that do not fit a
+            portable todo.txt metadata token or Firestore document id.
+    """
+    if value is None:
+        return None
+    task_id = value.strip()
+    if not task_id:
+        return None
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise TodoFormatError(
+            f"Invalid task id {task_id!r}. Expected letters, numbers, "
+            "underscores, or hyphens."
+        )
+    return task_id
+
+
 @dataclass(slots=True)
 class TodoItem:
     description: str = ""
@@ -133,10 +161,12 @@ class TodoItem:
     timer_started_at: datetime | None = None
     last_worked_at: datetime | None = None
     line_index: int = -1
+    task_id: str | None = None
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
 
     def __post_init__(self) -> None:
         self.priority = normalize_priority(self.priority)
+        self.task_id = normalize_task_id(self.task_id)
         self.creation_date = parse_date_string(self.creation_date)
         self.completion_date = parse_date_string(self.completion_date)
         self.time_spent_seconds = max(0, int(self.time_spent_seconds))
@@ -514,8 +544,16 @@ def parse_todo_line(line: str, line_index: int = -1) -> TodoItem:
     time_spent_seconds = 0
     timer_started_at: datetime | None = None
     last_worked_at: datetime | None = None
+    task_id: str | None = None
 
     for token in tokens[index:]:
+        if token.startswith("tid:"):
+            candidate = token.split(":", 1)[1]
+            try:
+                task_id = normalize_task_id(candidate)
+                continue
+            except TodoFormatError:
+                pass
         if token.startswith("spent:"):
             candidate = token.split(":", 1)[1]
             try:
@@ -547,6 +585,8 @@ def parse_todo_line(line: str, line_index: int = -1) -> TodoItem:
         timer_started_at=timer_started_at,
         last_worked_at=last_worked_at,
         line_index=line_index,
+        task_id=task_id,
+        id=task_id or uuid.uuid4().hex,
     )
 
 
@@ -566,6 +606,8 @@ def serialize_todo_line(item: TodoItem) -> str:
 
     if item.description:
         parts.append(normalize_single_line(item.description))
+    if item.task_id:
+        parts.append(f"tid:{item.task_id}")
     if item.time_spent_seconds > 0:
         parts.append(f"spent:{format_duration(item.time_spent_seconds)}")
     if item.last_worked_at is not None:
@@ -573,3 +615,177 @@ def serialize_todo_line(item: TodoItem) -> str:
     if item.timer_started_at is not None:
         parts.append(f"active:{format_timestamp(item.timer_started_at)}")
     return " ".join(part for part in parts if part)
+
+
+FIRESTORE_TASK_SCHEMA_VERSION = 1
+
+
+def ensure_task_id(item: TodoItem) -> str:
+    """Ensures a task has a stable id for sync matching.
+
+    Args:
+        item: Parsed todo item. If ``item.task_id`` is empty, this function
+            assigns the item's existing internal ``id`` as its stable task id.
+
+    Returns:
+        Stable task id suitable for a ``tid:<value>`` token and Firestore
+        document id.
+    """
+    task_id = normalize_task_id(item.task_id or item.id)
+    if task_id is None:
+        raise TodoFormatError("Task id could not be assigned.")
+    item.task_id = task_id
+    return task_id
+
+
+def todo_item_to_firestore_document(
+    item: TodoItem,
+    source_id: str = "",
+    *,
+    assign_task_id: bool = False,
+) -> dict[str, object]:
+    """Converts a parsed todo item into a Firestore task document.
+
+    Args:
+        item: Todo item parsed from a todo.txt line.
+        source_id: Source identifier for the local todo.txt file that owns the
+            task. Empty string means the caller has not assigned a source yet.
+        assign_task_id: When true, assign ``item.task_id`` if it is missing so
+            the resulting document can be matched back to the todo.txt line on
+            later syncs.
+
+    Returns:
+        Firestore-ready dictionary with these keys:
+        ``schema_version`` (int), ``tid`` (str), ``source_id`` (str),
+        ``description`` (str), ``completed`` (bool), ``priority`` (str),
+        ``creation_date`` (str), ``completion_date`` (str),
+        ``time_spent_seconds`` (int), ``timer_started_at`` (str),
+        ``last_worked_at`` (str), and ``line_index`` (int).
+    """
+    task_id = ensure_task_id(item) if assign_task_id else item.task_id
+    return {
+        "schema_version": FIRESTORE_TASK_SCHEMA_VERSION,
+        "tid": task_id or "",
+        "source_id": source_id,
+        "description": item.description,
+        "completed": item.completed,
+        "priority": item.priority or "",
+        "creation_date": item.creation_date or "",
+        "completion_date": item.completion_date or "",
+        "time_spent_seconds": item.time_spent_seconds,
+        "timer_started_at": (
+            format_timestamp(item.timer_started_at)
+            if item.timer_started_at is not None
+            else ""
+        ),
+        "last_worked_at": (
+            format_timestamp(item.last_worked_at)
+            if item.last_worked_at is not None
+            else ""
+        ),
+        "line_index": item.line_index,
+    }
+
+
+def firestore_document_to_todo_item(
+    document: Mapping[str, object],
+    *,
+    line_index: int | None = None,
+) -> TodoItem:
+    """Converts a Firestore task document back into a todo item.
+
+    Args:
+        document: Firestore task document produced by
+            ``todo_item_to_firestore_document``. Expected keys are
+            ``tid``, ``description``, ``completed``, ``priority``,
+            ``creation_date``, ``completion_date``, ``time_spent_seconds``,
+            ``timer_started_at``, ``last_worked_at``, and ``line_index``.
+        line_index: Optional replacement line index to use instead of the
+            document's ``line_index`` value.
+
+    Returns:
+        Todo item that can be serialized with ``serialize_todo_line``.
+
+    Raises:
+        KeyError: If a required document key is missing.
+        TodoFormatError: If priority, dates, timestamps, or task id values do
+            not match the todo.txt metadata formats.
+    """
+    task_id = normalize_task_id(document["tid"] or None)
+    item_line_index = (
+        int(document["line_index"]) if line_index is None else line_index
+    )
+    return TodoItem(
+        description=document["description"],
+        completed=document["completed"],
+        priority=document["priority"] or None,
+        creation_date=document["creation_date"] or None,
+        completion_date=document["completion_date"] or None,
+        time_spent_seconds=int(document["time_spent_seconds"]),
+        timer_started_at=parse_timestamp(document["timer_started_at"] or None),
+        last_worked_at=parse_timestamp(document["last_worked_at"] or None),
+        line_index=item_line_index,
+        task_id=task_id,
+        id=task_id or uuid.uuid4().hex,
+    )
+
+
+def todo_text_to_firestore_documents(
+    todo_text: str,
+    source_id: str = "",
+    *,
+    assign_task_ids: bool = False,
+) -> list[dict[str, object]]:
+    """Converts todo.txt content into Firestore task documents.
+
+    Args:
+        todo_text: Full todo.txt file contents.
+        source_id: Source identifier to attach to every produced document.
+        assign_task_ids: When true, assign missing stable task ids so exported
+            documents can be matched back to local lines on later syncs.
+
+    Returns:
+        List of Firestore-ready task dictionaries, one per non-empty todo.txt
+        line, preserving original line indexes.
+    """
+    documents: list[dict[str, object]] = []
+    for index, line in enumerate(todo_text.splitlines()):
+        if not line.strip():
+            continue
+        item = parse_todo_line(line, line_index=index)
+        documents.append(
+            todo_item_to_firestore_document(
+                item,
+                source_id,
+                assign_task_id=assign_task_ids,
+            )
+        )
+    return documents
+
+
+def firestore_documents_to_todo_text(
+    documents: Iterable[Mapping[str, object]],
+) -> str:
+    """Converts Firestore task documents into todo.txt content.
+
+    Args:
+        documents: Firestore task documents produced by
+            ``todo_item_to_firestore_document`` or loaded from Firestore with
+            the same schema. Documents are ordered by ``line_index`` before
+            export.
+
+    Returns:
+        todo.txt content containing one serialized task per line.
+
+    Raises:
+        KeyError: If a required document key is missing.
+        TodoFormatError: If a document contains invalid todo.txt metadata.
+    """
+    ordered_documents = sorted(
+        documents,
+        key=lambda document: (int(document["line_index"]), str(document["tid"])),
+    )
+    return "\n".join(
+        serialize_todo_line(firestore_document_to_todo_item(document))
+        for document in ordered_documents
+    )

--- a/todo_core.py
+++ b/todo_core.py
@@ -678,11 +678,7 @@ def todo_item_to_firestore_document(
     }
 
 
-def firestore_document_to_todo_item(
-    document: Mapping[str, object],
-    *,
-    line_index: int | None = None,
-) -> TodoItem:
+def firestore_document_to_todo_item(document: Mapping[str, object]) -> TodoItem:
     """Converts a Firestore task document back into a todo item.
 
     Args:
@@ -691,8 +687,6 @@ def firestore_document_to_todo_item(
             ``tid``, ``description``, ``completed``, ``priority``,
             ``creation_date``, ``completion_date``, ``time_spent_seconds``,
             ``timer_started_at``, ``last_worked_at``, and ``line_index``.
-        line_index: Optional replacement line index to use instead of the
-            document's ``line_index`` value.
 
     Returns:
         Todo item that can be serialized with ``serialize_todo_line``.
@@ -703,9 +697,6 @@ def firestore_document_to_todo_item(
             not match the todo.txt metadata formats.
     """
     task_id = validate_task_id(document["tid"]) if document["tid"] else None
-    item_line_index = (
-        int(document["line_index"]) if line_index is None else line_index
-    )
     return TodoItem(
         description=document["description"],
         completed=document["completed"],
@@ -715,7 +706,7 @@ def firestore_document_to_todo_item(
         time_spent_seconds=int(document["time_spent_seconds"]),
         timer_started_at=parse_timestamp(document["timer_started_at"] or None),
         last_worked_at=parse_timestamp(document["last_worked_at"] or None),
-        line_index=item_line_index,
+        line_index=int(document["line_index"]),
         task_id=task_id,
         id=task_id or uuid.uuid4().hex,
     )

--- a/todo_core.py
+++ b/todo_core.py
@@ -751,21 +751,19 @@ def firestore_document_to_todo_item(document: Mapping[str, object]) -> TodoItem:
     """Converts a Firestore task document back into a todo item.
 
     Args:
-        document: Firestore task document produced by
-            ``todo_item_to_firestore_document``. Expected keys are
-            ``tid``, ``description``, ``completed``, ``priority``,
-            ``creation_date``, ``completion_date``, ``time_spent_seconds``,
-            ``timer_started_at``, ``last_worked_at``, and ``line_index``.
+        document: Firestore task document matching
+            ``FIRESTORE_TASK_DOCUMENT_SCHEMA``.
 
     Returns:
         Todo item that can be serialized with ``serialize_todo_line``.
 
     Raises:
-        KeyError: If a required document key is missing.
-        TodoFormatError: If priority, dates, timestamps, or task id values do
-            not match the todo.txt metadata formats.
+        TodoFormatError: If the document does not match
+            ``FIRESTORE_TASK_DOCUMENT_SCHEMA`` or contains invalid todo.txt
+            metadata.
     """
-    task_id = validate_task_id(document["tid"]) if document["tid"] else None
+    validate_firestore_task_document(document)
+    task_id = validate_task_id(document["tid"])
     return TodoItem(
         description=document["description"],
         completed=document["completed"],
@@ -777,7 +775,7 @@ def firestore_document_to_todo_item(document: Mapping[str, object]) -> TodoItem:
         last_worked_at=parse_timestamp(document["last_worked_at"] or None),
         line_index=int(document["line_index"]),
         task_id=task_id,
-        id=task_id or uuid.uuid4().hex,
+        id=task_id,
     )
 
 
@@ -816,20 +814,23 @@ def firestore_documents_to_todo_text(
     """Converts Firestore task documents into todo.txt content.
 
     Args:
-        documents: Firestore task documents produced by
-            ``todo_item_to_firestore_document`` or loaded from Firestore with
-            the same schema. Documents are ordered by ``line_index`` before
-            export.
+        documents: Firestore task documents matching
+            ``FIRESTORE_TASK_DOCUMENT_SCHEMA``. Documents are ordered by
+            ``line_index`` before export.
 
     Returns:
         todo.txt content containing one serialized task per line.
 
     Raises:
-        KeyError: If a required document key is missing.
-        TodoFormatError: If a document contains invalid todo.txt metadata.
+        TodoFormatError: If a document does not match
+            ``FIRESTORE_TASK_DOCUMENT_SCHEMA`` or contains invalid todo.txt
+            metadata.
     """
+    validated_documents = list(documents)
+    for document in validated_documents:
+        validate_firestore_task_document(document)
     ordered_documents = sorted(
-        documents,
+        validated_documents,
         key=lambda document: (int(document["line_index"]), str(document["tid"])),
     )
     return "\n".join(

--- a/todo_core.py
+++ b/todo_core.py
@@ -123,31 +123,26 @@ def priority_sort_key(priority: str | None) -> tuple[str, int]:
     return (normalized[0], -len(normalized))
 
 
-def normalize_task_id(value: str | None) -> str | None:
-    """Normalizes a stable task id used for sync matching.
+def validate_task_id(value: str) -> str:
+    """Validates a stable task id used for sync matching.
 
     Args:
         value: Task id text from a ``tid:<value>`` token or Firestore task
-            document. Empty strings and ``None`` mean no stable task id.
+            document.
 
     Returns:
-        Normalized task id text, or ``None`` when no task id was provided.
+        The validated task id text.
 
     Raises:
         TodoFormatError: If the id contains characters that do not fit a
             portable todo.txt metadata token or Firestore document id.
     """
-    if value is None:
-        return None
-    task_id = value.strip()
-    if not task_id:
-        return None
-    if not TASK_ID_RE.fullmatch(task_id):
+    if not TASK_ID_RE.fullmatch(value):
         raise TodoFormatError(
-            f"Invalid task id {task_id!r}. Expected letters, numbers, "
+            f"Invalid task id {value!r}. Expected letters, numbers, "
             "underscores, or hyphens."
         )
-    return task_id
+    return value
 
 
 @dataclass(slots=True)
@@ -166,7 +161,8 @@ class TodoItem:
 
     def __post_init__(self) -> None:
         self.priority = normalize_priority(self.priority)
-        self.task_id = normalize_task_id(self.task_id)
+        if self.task_id is not None:
+            self.task_id = validate_task_id(self.task_id)
         self.creation_date = parse_date_string(self.creation_date)
         self.completion_date = parse_date_string(self.completion_date)
         self.time_spent_seconds = max(0, int(self.time_spent_seconds))
@@ -550,7 +546,7 @@ def parse_todo_line(line: str, line_index: int = -1) -> TodoItem:
         if token.startswith("tid:"):
             candidate = token.split(":", 1)[1]
             try:
-                task_id = normalize_task_id(candidate)
+                task_id = validate_task_id(candidate)
                 continue
             except TodoFormatError:
                 pass
@@ -631,9 +627,7 @@ def ensure_task_id(item: TodoItem) -> str:
         Stable task id suitable for a ``tid:<value>`` token and Firestore
         document id.
     """
-    task_id = normalize_task_id(item.task_id or item.id)
-    if task_id is None:
-        raise TodoFormatError("Task id could not be assigned.")
+    task_id = validate_task_id(item.task_id or item.id)
     item.task_id = task_id
     return task_id
 
@@ -711,7 +705,7 @@ def firestore_document_to_todo_item(
         TodoFormatError: If priority, dates, timestamps, or task id values do
             not match the todo.txt metadata formats.
     """
-    task_id = normalize_task_id(document["tid"] or None)
+    task_id = validate_task_id(document["tid"]) if document["tid"] else None
     item_line_index = (
         int(document["line_index"]) if line_index is None else line_index
     )

--- a/todo_core.py
+++ b/todo_core.py
@@ -723,21 +723,18 @@ def firestore_document_to_todo_item(
 
 def todo_text_to_firestore_documents(
     todo_text: str,
-    source_id: str = "",
-    *,
-    assign_task_ids: bool = False,
+    source_id: str,
 ) -> list[dict[str, object]]:
     """Converts todo.txt content into Firestore task documents.
 
     Args:
         todo_text: Full todo.txt file contents.
         source_id: Source identifier to attach to every produced document.
-        assign_task_ids: When true, assign missing stable task ids so exported
-            documents can be matched back to local lines on later syncs.
 
     Returns:
         List of Firestore-ready task dictionaries, one per non-empty todo.txt
-        line, preserving original line indexes.
+        line, preserving original line indexes and assigning missing stable
+        task ids.
     """
     documents: list[dict[str, object]] = []
     for index, line in enumerate(todo_text.splitlines()):


### PR DESCRIPTION
## Summary
- add stable 	id:<id> parsing and serialization for future sync matching
- add helpers to convert TodoItem values and todo.txt content into Firestore-ready task documents
- add helpers to convert Firestore task documents back into TodoItem values and todo.txt content
- keep this PR local-only with no Firebase network behavior

Closes #84

## Testing
- python -m py_compile todo_timer.pyw todo_core.py
- python -c round-trip todo.txt -> Firestore document -> todo.txt with existing tid and timer metadata
- python -c assign missing tid during document export and serialize back to todo.txt