### PR TITLE
Automatically merge safe external todo.txt time changes

### DIFF
--- a/tests/test_external_todo_time_merge.py
+++ b/tests/test_external_todo_time_merge.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from todo_core import TodoFileShadow, TodoStore
+
+
+class ExternalTodoTimeMergeTests(unittest.TestCase):
+    def test_lastworked_only_change_can_auto_accept_without_merge_base(self) -> None:
+        """Checks the narrow external metadata case that needs no merge base."""
+        with TemporaryDirectory() as temp_dir:
+            shadow = TodoFileShadow(Path(temp_dir) / "shadows")
+            before = (
+                "Task one tid:abc spent:01:00:00 "
+                "lastworked:2026-06-16-10-00-00\n"
+            )
+            after = (
+                "Task one tid:abc spent:01:00:00 "
+                "lastworked:2026-06-16-11-00-00\n"
+            )
+
+            diff = shadow.describe_task_line_changes(before, after)
+
+            self.assertTrue(TodoFileShadow.diff_updates_only_time_metadata(diff))
+            self.assertTrue(
+                TodoFileShadow.diff_can_auto_accept_without_merge_base(diff)
+            )
+
+    def test_divergent_spent_changes_require_a_merge_base(self) -> None:
+        """Simulates two machines recording different time from one old file."""
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            shadow = TodoFileShadow(root / "shadows")
+            todo_path = root / "todo.txt"
+
+            common_start = "Task one tid:abc spent:00:00:00\n"
+            machine_a_after_day_one = "Task one tid:abc spent:01:00:00\n"
+            machine_b_after_day_two = "Task one tid:abc spent:02:00:00\n"
+
+            todo_path.write_text(machine_b_after_day_two, encoding="utf-8")
+            store = TodoStore()
+            store.load(todo_path)
+            shadow.write_baseline(todo_path, machine_b_after_day_two)
+
+            todo_path.write_text(machine_a_after_day_one, encoding="utf-8")
+            change = shadow.detect_external_change(todo_path)
+
+            self.assertIsNotNone(change)
+            self.assertEqual(store.serialize_content(), machine_b_after_day_two)
+            self.assertTrue(
+                TodoFileShadow.diff_updates_only_time_metadata(
+                    change.task_diff
+                )
+            )
+            self.assertFalse(
+                TodoFileShadow.diff_can_auto_accept_without_merge_base(
+                    change.task_diff
+                )
+            )
+            self.assertNotEqual(common_start, machine_a_after_day_one)
+            self.assertNotEqual(common_start, machine_b_after_day_two)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo_core.py
+++ b/todo_core.py
@@ -525,6 +525,30 @@ class TodoFileShadow:
         )
 
     @staticmethod
+    def diff_can_auto_accept_without_merge_base(
+        task_diff: TodoTaskLineDiff,
+    ) -> bool:
+        """Returns whether a diff is safe to reload without a merge base.
+
+        Args:
+            task_diff: Task-level diff produced by describe_task_line_changes.
+
+        Returns:
+            True when every changed task is matched by ``tid`` and only
+            non-total time metadata changed. Changes to ``spent:`` or
+            ``active:`` return False because they can replace work from another
+            machine unless a common ancestor is available for summing deltas.
+        """
+        if not TodoFileShadow.diff_updates_only_time_metadata(task_diff):
+            return False
+        return all(
+            TodoFileShadow.task_change_updates_only_non_total_time_metadata(
+                change
+            )
+            for change in task_diff.modified_tasks
+        )
+
+    @staticmethod
     def task_change_updates_only_time_metadata(
         change: TodoTaskLineChange,
     ) -> bool:
@@ -557,6 +581,34 @@ class TodoFileShadow:
             or shadow.last_worked_at != disk.last_worked_at
         )
         return non_time_fields_match and time_fields_changed
+
+    @staticmethod
+    def task_change_updates_only_non_total_time_metadata(
+        change: TodoTaskLineChange,
+    ) -> bool:
+        """Returns whether one task changed only non-total time metadata.
+
+        Args:
+            change: Modified task line with both baseline and disk parsed
+                TodoItem values.
+
+        Returns:
+            True when ``lastworked:`` changed without changing ``spent:`` or
+            ``active:``. These changes are safe to reload without a common
+            ancestor because they do not replace accumulated work totals.
+        """
+        if not TodoFileShadow.task_change_updates_only_time_metadata(change):
+            return False
+
+        shadow = change.shadow_item
+        disk = change.disk_item
+        if shadow is None or disk is None:
+            return False
+        return (
+            shadow.time_spent_seconds == disk.time_spent_seconds
+            and shadow.timer_started_at == disk.timer_started_at
+            and shadow.last_worked_at != disk.last_worked_at
+        )
 
     @staticmethod
     def changed_unmatched_lines(

--- a/todo_core.py
+++ b/todo_core.py
@@ -275,6 +275,10 @@ class TodoTaskLineChange:
             task was removed from disk.
         shadow_description: Parsed baseline task description.
         disk_description: Parsed current disk task description.
+        shadow_item: Parsed baseline task, or None when the task is new on
+            disk.
+        disk_item: Parsed current disk task, or None when the task was removed
+            from disk.
     """
 
     task_id: str
@@ -284,6 +288,8 @@ class TodoTaskLineChange:
     disk_text: str
     shadow_description: str
     disk_description: str
+    shadow_item: TodoItem | None
+    disk_item: TodoItem | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -445,6 +451,8 @@ class TodoFileShadow:
                     disk_text=disk_task.text,
                     shadow_description=shadow_task.item.description,
                     disk_description=disk_task.item.description,
+                    shadow_item=shadow_task.item,
+                    disk_item=disk_task.item,
                 )
             )
 
@@ -459,6 +467,8 @@ class TodoFileShadow:
                     disk_text=disk_task.text,
                     shadow_description="",
                     disk_description=disk_task.item.description,
+                    shadow_item=None,
+                    disk_item=disk_task.item,
                 )
             )
 
@@ -473,6 +483,8 @@ class TodoFileShadow:
                     disk_text="",
                     shadow_description=shadow_task.item.description,
                     disk_description="",
+                    shadow_item=shadow_task.item,
+                    disk_item=None,
                 )
             )
 
@@ -483,6 +495,68 @@ class TodoFileShadow:
             unmatched_added_lines=unmatched_added_lines,
             unmatched_removed_lines=unmatched_removed_lines,
         )
+
+    @staticmethod
+    def diff_updates_only_time_metadata(
+        task_diff: TodoTaskLineDiff,
+    ) -> bool:
+        """Returns whether a task diff is safe time metadata only.
+
+        Args:
+            task_diff: Task-level diff produced by describe_task_line_changes.
+
+        Returns:
+            True when every changed task is matched by ``tid`` and changes
+            only ``spent:``, ``lastworked:``, or ``active:`` metadata. False
+            when tasks were added, removed, unmatched, or changed in any
+            non-time field.
+        """
+        if (
+            not task_diff.modified_tasks
+            or task_diff.added_tasks
+            or task_diff.removed_tasks
+            or task_diff.unmatched_added_lines
+            or task_diff.unmatched_removed_lines
+        ):
+            return False
+        return all(
+            TodoFileShadow.task_change_updates_only_time_metadata(change)
+            for change in task_diff.modified_tasks
+        )
+
+    @staticmethod
+    def task_change_updates_only_time_metadata(
+        change: TodoTaskLineChange,
+    ) -> bool:
+        """Returns whether one matched task changed only time metadata.
+
+        Args:
+            change: Modified task line with both baseline and disk parsed
+                TodoItem values.
+
+        Returns:
+            True when all non-time task fields are identical and at least one
+            time metadata field changed.
+        """
+        if change.shadow_item is None or change.disk_item is None:
+            return False
+
+        shadow = change.shadow_item
+        disk = change.disk_item
+        non_time_fields_match = (
+            shadow.task_id == disk.task_id
+            and shadow.description == disk.description
+            and shadow.completed == disk.completed
+            and shadow.priority == disk.priority
+            and shadow.creation_date == disk.creation_date
+            and shadow.completion_date == disk.completion_date
+        )
+        time_fields_changed = (
+            shadow.time_spent_seconds != disk.time_spent_seconds
+            or shadow.timer_started_at != disk.timer_started_at
+            or shadow.last_worked_at != disk.last_worked_at
+        )
+        return non_time_fields_match and time_fields_changed
 
     @staticmethod
     def changed_unmatched_lines(
@@ -650,12 +724,21 @@ class TodoStore:
     def save(self) -> None:
         if self.path is None:
             raise RuntimeError("No todo.txt file is loaded.")
+        self._atomic_write(self.path, self.serialize_content())
+        for index, item in enumerate(self.items):
+            item.line_index = index
+
+    def serialize_content(self) -> str:
+        """Serializes the store to the exact todo.txt save content.
+
+        Returns:
+            Text that TodoStore.save writes to disk, including the trailing
+            newline when at least one task exists.
+        """
         serialized = "\n".join(serialize_todo_line(item) for item in self.items)
         if serialized:
             serialized += "\n"
-        self._atomic_write(self.path, serialized)
-        for index, item in enumerate(self.items):
-            item.line_index = index
+        return serialized
 
     def archive_completed(self, archive_path: str | os.PathLike[str]) -> int:
         if self.path is None:

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -2343,7 +2343,9 @@ class TodoTimerApp:
         """
         if self.store.running_items():
             return False
-        if not self.todo_shadow.diff_updates_only_time_metadata(change.task_diff):
+        if not self.todo_shadow.diff_can_auto_accept_without_merge_base(
+            change.task_diff
+        ):
             return False
         if self.store.serialize_content() != change.shadow_content:
             return False

--- a/todo_timer.pyw
+++ b/todo_timer.pyw
@@ -2301,6 +2301,8 @@ class TodoTimerApp:
         change = self.todo_shadow.detect_external_change(self.store.path)
         if change is None:
             return True
+        if self.accept_safe_external_time_change(change):
+            return False
 
         choice = messagebox.askyesnocancel(
             APP_TITLE,
@@ -2327,6 +2329,30 @@ class TodoTimerApp:
             "Save canceled; current app changes are still unsaved."
         )
         return False
+
+    def accept_safe_external_time_change(self, change: TodoFileChange) -> bool:
+        """Accepts external time-only updates when local state is unchanged.
+
+        Args:
+            change: External todo.txt change detected against the shadow
+                baseline.
+
+        Returns:
+            True when the app reloaded the disk file and accepted it as the new
+            baseline. False when the change still requires a user prompt.
+        """
+        if self.store.running_items():
+            return False
+        if not self.todo_shadow.diff_updates_only_time_metadata(change.task_diff):
+            return False
+        if self.store.serialize_content() != change.shadow_content:
+            return False
+
+        self.store.load(change.todo_path)
+        self.accept_current_todo_file_as_baseline()
+        self.refresh_tree()
+        self.status_var.set("Accepted external time-only todo.txt change.")
+        return True
 
     def save_todo_file(self) -> bool:
         """Saves todo.txt after checking for external file changes.
@@ -2355,6 +2381,8 @@ class TodoTimerApp:
         )
         change = self.todo_shadow.detect_external_change(self.store.path)
         if change is None:
+            return
+        if self.accept_safe_external_time_change(change):
             return
 
         self.external_todo_change_prompt_open = True


### PR DESCRIPTION
## Summary
- identify external tid-matched task changes that only update time metadata
- automatically accept only non-total time metadata changes, currently lastworked-only updates, when local todo.txt state still matches the shadow baseline
- keep prompting for local active timers, local unsaved changes, spent/active total changes, added/removed tasks, unmatched lines, or non-time task changes

## Notes
The Dropbox two-machine case where both machines record different spent values is not safe to merge with the current single shadow baseline. This PR now has a regression test for that case and keeps prompting instead of replacing one machine's saved time with the other. Correctly summing those values needs a follow-up merge-base/tombstone style PR that preserves the common ancestor.

## Validation
- python -m py_compile todo_timer.pyw todo_core.py
- python -m unittest tests.test_external_todo_time_merge
- targeted TodoFileShadow checks for safe lastworked-only changes
- targeted checks that divergent spent changes, description changes, priority changes, added tasks, and unmatched changes are not treated as auto-acceptable
- targeted TodoStore serialization check used by the local-state gate

Closes #96